### PR TITLE
Fix FSLogix recipes

### DIFF
--- a/Microsoft/FSLogix.download.recipe
+++ b/Microsoft/FSLogix.download.recipe
@@ -11,11 +11,9 @@
         <key>NAME</key>
         <string>FSLogix</string>
         <key>SEARCH_URL</key>
-        <string>https://learn.microsoft.com/en-us/fslogix/whats-new</string>
+        <string>https://aka.ms/fslogix-latest</string>
         <key>SEARCH_PATTERN</key>
-        <string>https\:\/\/download\.microsoft\.com\/download\/.*\/FSLogix_Apps_[\d\.]{3,}\.zip</string>
-        <key>USER_AGENT</key>
-        <string>Mozilla/5.0 (Windows NT 6.3; Win64, x64; Trident/7.0; rv:11.0) like Gecko</string>
+        <string>https://download\.microsoft\.com/download/[a-f0-9\-/]+/FSLogix_Apps_[\d\.]+\.zip</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.9</string>
@@ -39,11 +37,6 @@
             <dict>
                 <key>url</key>
                 <string>%match%</string>
-                <key>request_headers</key>
-                <dict>
-                    <key>user-agent</key>
-                    <string>%USER_AGENT%</string>
-                </dict>
             </dict>
         </dict>
         <dict>
@@ -63,7 +56,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pattern</key>
-                <string>%destination_path%/*/x64/Release/*.exe</string>
+                <string>%destination_path%/x64/Release/*.exe</string>
             </dict>
         </dict>
         <dict>

--- a/Microsoft/FSLogix.download.recipe
+++ b/Microsoft/FSLogix.download.recipe
@@ -41,6 +41,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -93,10 +97,6 @@
                 <key>predicate</key>
                 <string>version == "" OR version == "None" </string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
This PR updates the FSLogix download method and adjusts the timing of EndOfCheckPhase.

Verbose recipe run output:

```
% autopkg run -vvcq 'Microsoft/FSLogix.download.recipe'
Processing Microsoft/FSLogix.download.recipe...
WARNING: Microsoft/FSLogix.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'https://download\\.microsoft\\.com/download/[a-f0-9\\-/]+/FSLogix_Apps_[\\d\\.]+\\.zip',
           'url': 'https://aka.ms/fslogix-latest'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://download.microsoft.com/download/e/c/4/ec4b55b3-d2f3-4610-aebd-56478eb0d582/FSLogix_Apps_2.9.8884.27471.zip
{'Output': {'match': 'https://download.microsoft.com/download/e/c/4/ec4b55b3-d2f3-4610-aebd-56478eb0d582/FSLogix_Apps_2.9.8884.27471.zip'}}
URLDownloader
{'Input': {'url': 'https://download.microsoft.com/download/e/c/4/ec4b55b3-d2f3-4610-aebd-56478eb0d582/FSLogix_Apps_2.9.8884.27471.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 29 Apr 2024 21:31:21 GMT
URLDownloader: Storing new ETag header: "0x8DC6893B69F4662"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.iancohn.download.FSLogix-Win/downloads/FSLogix_Apps_2.9.8884.27471.zip
{'Output': {'download_changed': True,
            'etag': '"0x8DC6893B69F4662"',
            'last_modified': 'Mon, 29 Apr 2024 21:31:21 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.iancohn.download.FSLogix-Win/downloads/FSLogix_Apps_2.9.8884.27471.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.iancohn.download.FSLogix-Win/downloads/FSLogix_Apps_2.9.8884.27471.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.iancohn.download.FSLogix-Win/receipts/FSLogix.download-receipt-20241226-142843.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.iancohn.download.FSLogix-Win/downloads/FSLogix_Apps_2.9.8884.27471.zip
```
