### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/Dell/DellCommandPSProvider-Win.download.recipe
+++ b/Dell/DellCommandPSProvider-Win.download.recipe
@@ -47,6 +47,10 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>Unarchiver</string>
 			<key>Arguments</key>
 			<dict>
@@ -190,10 +194,6 @@
 					</dict>
 				</dict>
 			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>

--- a/Dell/DellCommandUpdate-Win64.download.recipe
+++ b/Dell/DellCommandUpdate-Win64.download.recipe
@@ -43,6 +43,10 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>com.github.iancohn.SharedProcessors/VirusTotalAnalyzerV3</string>
 			<key>Arguments</key>
 			<dict>
@@ -60,10 +64,6 @@
 					</dict>
 				</dict>
 			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>

--- a/Dell/DellSupportAssistPlugin-Win64.download.recipe
+++ b/Dell/DellSupportAssistPlugin-Win64.download.recipe
@@ -43,6 +43,10 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>com.github.iancohn.SharedProcessors/VirusTotalAnalyzerV3</string>
 			<key>Arguments</key>
 			<dict>
@@ -60,10 +64,6 @@
 					</dict>
 				</dict>
 			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>

--- a/Microsoft/OneDrive-Win.download.recipe
+++ b/Microsoft/OneDrive-Win.download.recipe
@@ -37,6 +37,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>com.github.hansen-m.SharedProcessors/WinInstallerExtractor</string>
             <key>Arguments</key>
             <dict/>
@@ -49,10 +53,6 @@
                 <key>predicate</key>
                 <string>version == "" OR version == "None" </string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.